### PR TITLE
Automatically synchronize CoreInfo when on connect and disconnect

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -36,7 +36,6 @@ set(SOURCES
 
     # needed for automoc
     abstractui.h
-    clientcoreinfo.h
 )
 
 if (USE_QT5)

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -101,6 +101,7 @@ Client::Client(QObject *parent)
     _backlogManager(new ClientBacklogManager(this)),
     _bufferViewManager(0),
     _bufferViewOverlay(new BufferViewOverlay(this)),
+    _coreInfo(nullptr),
     _dccConfig(0),
     _ircListHelper(new ClientIrcListHelper(this)),
     _inputHandler(0),
@@ -399,6 +400,11 @@ void Client::setSyncedToCore()
     SignalProxy *p = signalProxy();
     p->synchronize(bufferSyncer());
 
+    // create CoreInfo
+    Q_ASSERT(!_coreInfo);
+    _coreInfo = new CoreInfo(this);
+    p->synchronize(coreInfo());
+
     // create a new BufferViewManager
     Q_ASSERT(!_bufferViewManager);
     _bufferViewManager = new ClientBufferViewManager(p, this);
@@ -495,6 +501,11 @@ void Client::setDisconnectedFromCore()
     if (_bufferSyncer) {
         _bufferSyncer->deleteLater();
         _bufferSyncer = 0;
+    }
+
+    if (_coreInfo) {
+        _coreInfo->deleteLater();
+        _coreInfo = nullptr;
     }
 
     if (_bufferViewManager) {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -24,6 +24,7 @@
 #include <QPointer>
 
 #include "bufferinfo.h"
+#include "coreinfo.h"
 #include "coreaccount.h"
 #include "coreconnection.h"
 #include "highlightrulemanager.h"
@@ -115,6 +116,7 @@ public:
 
     static inline ClientAliasManager *aliasManager() { return instance()->_aliasManager; }
     static inline ClientBacklogManager *backlogManager() { return instance()->_backlogManager; }
+    static inline CoreInfo *coreInfo() { return instance()->_coreInfo; }
     static inline DccConfig *dccConfig() { return instance()->_dccConfig; }
     static inline ClientIrcListHelper *ircListHelper() { return instance()->_ircListHelper; }
     static inline ClientBufferViewManager *bufferViewManager() { return instance()->_bufferViewManager; }
@@ -264,6 +266,7 @@ private:
     ClientBacklogManager *_backlogManager;
     ClientBufferViewManager *_bufferViewManager;
     BufferViewOverlay *_bufferViewOverlay;
+    CoreInfo *_coreInfo;
     DccConfig *_dccConfig;
     ClientIrcListHelper *_ircListHelper;
     ClientUserInputHandler *_inputHandler;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     bufferviewconfig.cpp
     bufferviewmanager.cpp
     compressor.cpp
+    coreinfo.cpp
     ctcpevent.cpp
     dccconfig.cpp
     event.cpp
@@ -44,7 +45,6 @@ set(SOURCES
     protocols/legacy/legacypeer.cpp
 
     # needed for automoc
-    coreinfo.h
     irccap.h
     protocol.h
 )

--- a/src/common/coreinfo.cpp
+++ b/src/common/coreinfo.cpp
@@ -18,34 +18,26 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#pragma once
+#include "coreinfo.h"
 
-#include "syncableobject.h"
+INIT_SYNCABLE_OBJECT(CoreInfo)
+CoreInfo::CoreInfo(QObject *parent) : SyncableObject(parent) {}
 
-/*
- * gather various information about the core.
- */
-
-class CoreInfo : public SyncableObject
+QVariantMap CoreInfo::coreData() const
 {
-    Q_OBJECT
-    SYNCABLE_OBJECT
+    return _coreData;
+}
 
-    Q_PROPERTY(QVariantMap coreData READ coreData WRITE setCoreData)
+void CoreInfo::setCoreData(const QVariantMap &coreData)
+{
+    _coreData = coreData;
+    SYNC(ARG(coreData));
+    emit coreDataChanged(coreData);
+}
 
-public:
-    explicit CoreInfo(QObject *parent = nullptr);
-    inline QVariant &at(const QString &key) { return _coreData[key]; }
-
-    void setConnectedClientData(int, QVariantList);
-
-signals:
-    void coreDataChanged(QVariantMap);
-
-public slots:
-    QVariantMap coreData() const;
-    void setCoreData(const QVariantMap &);
-
-private:
-    QVariantMap _coreData;
-};
+void CoreInfo::setConnectedClientData(const int peerCount, const QVariantList peerData)
+{
+    _coreData["sessionConnectedClients"] = peerCount;
+    _coreData["sessionConnectedClientData"] = peerData;
+    setCoreData(_coreData);
+}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,7 +12,6 @@ set(SOURCES
     corebuffersyncer.cpp
     corebufferviewconfig.cpp
     corebufferviewmanager.cpp
-    corecoreinfo.cpp
     coredccconfig.cpp
     corehighlightrulemanager.cpp
     coreidentity.cpp

--- a/src/core/coresession.cpp
+++ b/src/core/coresession.cpp
@@ -31,6 +31,7 @@
 #include "coreeventmanager.h"
 #include "coreidentity.h"
 #include "coreignorelistmanager.h"
+#include "coreinfo.h"
 #include "coreirclisthelper.h"
 #include "corenetwork.h"
 #include "corenetworkconfig.h"
@@ -68,7 +69,7 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     _dccConfig(new CoreDccConfig(this)),
     _ircListHelper(new CoreIrcListHelper(this)),
     _networkConfig(new CoreNetworkConfig("GlobalNetworkConfig", this)),
-    _coreInfo(this),
+    _coreInfo(new CoreInfo(this)),
     _transferManager(new CoreTransferManager(this)),
     _eventManager(new CoreEventManager(this)),
     _eventStringifier(new EventStringifier(this)),
@@ -109,6 +110,13 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->attachSlot(SIGNAL(kickClient(int)), this, SLOT(kickClient(int)));
     p->attachSignal(this, SIGNAL(disconnectFromCore()));
 
+    QVariantMap data;
+    data["quasselVersion"] = Quassel::buildInfo().fancyVersionString;
+    data["quasselBuildDate"] = Quassel::buildInfo().commitDate; // "BuildDate" for compatibility
+    data["startTime"] = Core::instance()->startTime();
+    data["sessionConnectedClients"] = 0;
+    _coreInfo->setCoreData(data);
+
     loadSettings();
     initScriptEngine();
 
@@ -130,7 +138,7 @@ CoreSession::CoreSession(UserId uid, bool restoreState, QObject *parent)
     p->synchronize(dccConfig());
     p->synchronize(ircListHelper());
     p->synchronize(networkConfig());
-    p->synchronize(&_coreInfo);
+    p->synchronize(_coreInfo);
     p->synchronize(&_ignoreListManager);
     p->synchronize(&_highlightRuleManager);
     p->synchronize(transferManager());
@@ -264,6 +272,7 @@ void CoreSession::addClient(RemotePeer *peer)
 {
     peer->dispatch(sessionState());
     signalProxy()->addPeer(peer);
+    _coreInfo->setConnectedClientData(signalProxy()->peerCount(), signalProxy()->peerData());
 }
 
 
@@ -279,6 +288,7 @@ void CoreSession::removeClient(Peer *peer)
     RemotePeer *p = qobject_cast<RemotePeer *>(peer);
     if (p)
         quInfo() << qPrintable(tr("Client")) << p->description() << qPrintable(tr("disconnected (UserId: %1).").arg(user().toInt()));
+    _coreInfo->setConnectedClientData(signalProxy()->peerCount(), signalProxy()->peerData());
 }
 
 

--- a/src/core/coresession.h
+++ b/src/core/coresession.h
@@ -24,7 +24,7 @@
 #include <QString>
 #include <QVariant>
 
-#include "corecoreinfo.h"
+#include "coreinfo.h"
 #include "corealiasmanager.h"
 #include "corehighlightrulemanager.h"
 #include "coreignorelistmanager.h"
@@ -219,7 +219,7 @@ private:
     CoreDccConfig *_dccConfig;
     CoreIrcListHelper *_ircListHelper;
     CoreNetworkConfig *_networkConfig;
-    CoreCoreInfo _coreInfo;
+    CoreInfo *_coreInfo;
     CoreTransferManager *_transferManager;
 
     EventManager *_eventManager;

--- a/src/qtui/coreinfodlg.cpp
+++ b/src/qtui/coreinfodlg.cpp
@@ -20,72 +20,83 @@
 
 #include "coreinfodlg.h"
 
-#include <QDateTime>
-
 #include "client.h"
-#include "signalproxy.h"
 #include "bufferwidget.h"
-#include "coresessionwidget.h"
 
-CoreInfoDlg::CoreInfoDlg(QWidget *parent)
-    : QDialog(parent),
-    _coreInfo(this)
-{
+CoreInfoDlg::CoreInfoDlg(QWidget *parent) : QDialog(parent) {
     ui.setupUi(this);
-    connect(&_coreInfo, SIGNAL(initDone()), this, SLOT(coreInfoAvailable()));
-    connect(&_coreInfo, SIGNAL(updatedRemotely()), this, SLOT(coreInfoAvailable()));
-    Client::signalProxy()->synchronize(&_coreInfo);
-}
+    CoreInfo *coreInfo = Client::coreInfo();
+    connect(coreInfo, SIGNAL(coreDataChanged(const QVariantMap &)), this, SLOT(coreInfoChanged(const QVariantMap &)));
 
-
-void CoreInfoDlg::coreInfoAvailable()
-{
-    ui.labelCoreVersion->setText(_coreInfo["quasselVersion"].toString());
-    ui.labelCoreVersionDate->setText(_coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
-    ui.labelClientCount->setNum(_coreInfo["sessionConnectedClients"].toInt());
-
-    // Clear existing widgets from the core session list
-    // See https://stackoverflow.com/questions/3940409/how-to-clear-all-the-widgets-in-parent-widgets
-    // And https://forum.qt.io/topic/30099/solved-remove-widgets-from-layout
-    QLayoutItem *child;
-    while ((child = ui.coreSessionContainer->takeAt(0)) != NULL) {
-        // Remove the widget item
-        child->widget()->deleteLater();
-    }
-
-    auto coreSessionSupported = false;
-    for (const auto &peerData : _coreInfo["sessionConnectedClientData"].toList()) {
-        coreSessionSupported = true;
-
-        auto coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
-        coreSessionWidget->setData(peerData.toMap());
-        ui.coreSessionContainer->addWidget(coreSessionWidget);
-        connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
-    }
-
-    ui.coreSessionScrollArea->setVisible(coreSessionSupported);
-
-    ui.coreSessionContainer->addStretch(1);
+    coreInfoChanged(coreInfo->coreData());
 
     updateUptime();
     startTimer(1000);
 }
 
 
-void CoreInfoDlg::updateUptime()
-{
-    QDateTime startTime = _coreInfo["startTime"].toDateTime();
+void CoreInfoDlg::coreInfoChanged(const QVariantMap &coreInfo) {
+    ui.labelCoreVersion->setText(coreInfo["quasselVersion"].toString());
+    ui.labelCoreVersionDate->setText(coreInfo["quasselBuildDate"].toString()); // "BuildDate" for compatibility
+    ui.labelClientCount->setNum(coreInfo["sessionConnectedClients"].toInt());
 
-    int uptime = startTime.secsTo(QDateTime::currentDateTime().toUTC());
-    int updays = uptime / 86400; uptime %= 86400;
-    int uphours = uptime / 3600; uptime %= 3600;
-    int upmins = uptime / 60; uptime %= 60;
+    auto coreSessionSupported = false;
+    auto ids = _widgets.keys();
+    for (const auto &peerData : coreInfo["sessionConnectedClientData"].toList()) {
+        coreSessionSupported = true;
 
-    QString uptimeText = tr("%n Day(s)", "", updays)
-                         + tr(" %1:%2:%3 (since %4)").arg(uphours, 2, 10, QChar('0')).arg(upmins, 2, 10, QChar('0')).arg(uptime, 2, 10, QChar('0')).arg(startTime.toLocalTime().toString(Qt::TextDate));
-    ui.labelUptime->setText(uptimeText);
+        auto peerMap = peerData.toMap();
+        int peerId = peerMap["id"].toInt();
+
+        ids.removeAll(peerId);
+
+        bool isNew = false;
+        CoreSessionWidget *coreSessionWidget = _widgets[peerId];
+        if (coreSessionWidget == nullptr) {
+            coreSessionWidget = new CoreSessionWidget(ui.coreSessionScrollContainer);
+            isNew = true;
+        }
+        coreSessionWidget->setData(peerMap);
+        if (isNew) {
+            _widgets[peerId] = coreSessionWidget;
+            ui.coreSessionContainer->addWidget(coreSessionWidget);
+            connect(coreSessionWidget, SIGNAL(disconnectClicked(int)), this, SLOT(disconnectClicked(int)));
+        }
+    }
+
+    for (const auto &key : ids) {
+        delete _widgets[key];
+        _widgets.remove(key);
+    }
+
+    ui.coreSessionScrollArea->setVisible(coreSessionSupported);
+    ui.coreSessionContainer->addStretch(1);
 }
-void CoreInfoDlg::disconnectClicked(int peerId)
-{
+
+
+void CoreInfoDlg::updateUptime() {
+    CoreInfo *coreInfo = Client::coreInfo();
+    if (coreInfo) {
+        QDateTime startTime = coreInfo->at("startTime").toDateTime();
+
+        int64_t uptime = startTime.secsTo(QDateTime::currentDateTime().toUTC());
+        int64_t updays = uptime / 86400;
+        uptime %= 86400;
+        int64_t uphours = uptime / 3600;
+        uptime %= 3600;
+        int64_t upmins = uptime / 60;
+        uptime %= 60;
+
+        QString uptimeText = tr("%n Day(s)", "", updays) +
+                             tr(" %1:%2:%3 (since %4)")
+                                     .arg(uphours, 2, 10, QChar('0'))
+                                     .arg(upmins, 2, 10, QChar('0'))
+                                     .arg(uptime, 2, 10, QChar('0'))
+                                     .arg(startTime.toLocalTime().toString(Qt::TextDate));
+        ui.labelUptime->setText(uptimeText);
+    }
+}
+
+void CoreInfoDlg::disconnectClicked(int peerId) {
     Client::kickClient(peerId);
 }

--- a/src/qtui/coreinfodlg.h
+++ b/src/qtui/coreinfodlg.h
@@ -18,26 +18,25 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.         *
  ***************************************************************************/
 
-#ifndef COREINFODLG_H
-#define COREINFODLG_H
+#pragma once
 
-#include "ui_coreinfodlg.h"
 #include <QDialog>
 
-#include "clientcoreinfo.h"
+#include "ui_coreinfodlg.h"
+#include "coreinfo.h"
+#include "coresessionwidget.h"
 
-class CoreInfoDlg : public QDialog
-{
-    Q_OBJECT
+class CoreInfoDlg : public QDialog {
+Q_OBJECT
 
 public:
-    CoreInfoDlg(QWidget *parent = 0);
+    explicit CoreInfoDlg(QWidget *parent = nullptr);
 
 public slots:
-    void coreInfoAvailable();
+    void coreInfoChanged(const QVariantMap &);
 
 protected:
-    virtual void timerEvent(QTimerEvent *) { updateUptime(); }
+    void timerEvent(QTimerEvent *) override { updateUptime(); }
 
 private slots:
     void on_closeButton_clicked() { reject(); }
@@ -46,8 +45,5 @@ private slots:
 
 private:
     Ui::CoreInfoDlg ui;
-    ClientCoreInfo _coreInfo;
+    QMap<int, CoreSessionWidget *> _widgets;
 };
-
-
-#endif //COREINFODLG_H


### PR DESCRIPTION
This refactors CoreInfo to be a single common class rather than
separate classes for the core and client, adjusts it to properly
use the SyncableObject infrastructure, and adds support for
dynamically updating the list on both the client and core when a
client connects or disconnects, keeping the list up-to-date at all
times.  Forwards and backwards compatibility is maintained, though
the updated client is required in order for the automatic updating
to work.