### PR TITLE
Fix crash caused by repeated kicks of an already-kicked client

### DIFF
--- a/src/common/signalproxy.cpp
+++ b/src/common/signalproxy.cpp
@@ -847,7 +847,10 @@ QVariantList SignalProxy::peerData() {
 }
 
 Peer *SignalProxy::peerById(int peerId) {
-    return _peerMap[peerId];
+    // We use ::value() here instead of the [] operator because the latter has the side-effect
+    // of automatically inserting a null value with the passed key into the map.  See
+    // https://doc.qt.io/qt-5/qhash.html#operator-5b-5d and https://doc.qt.io/qt-5/qhash.html#value.
+    return _peerMap.value(peerId);
 }
 
 void SignalProxy::restrictTargetPeers(QSet<Peer*> peers, std::function<void()> closure)


### PR DESCRIPTION
As it turns out, the QHash[] operator implicitly adds nullptrs to
the map when called with a nonexistent key.  If a user clicked the
button to kick another client multiple times, this would cause a
nullptr to be inserted into the peerMap, then causing a crash later
on at least when another client connected.  To solve the problem,
the value() method is used instead, which has no such side-effect.
A big thanks to @digitalcircuit for discovering this behavior.