### PR TITLE
IrcUser: Rename lastAwayMessage to lastAwayMessageTime

### DIFF
--- a/src/common/ircuser.cpp
+++ b/src/common/ircuser.cpp
@@ -40,7 +40,7 @@ IrcUser::IrcUser(const QString &hostmask, Network *network) : SyncableObject(net
     _server(),
     // _idleTime(QDateTime::currentDateTime()),
     _ircOperator(),
-    _lastAwayMessage(),
+    _lastAwayMessageTime(),
     _whoisServiceReply(),
     _encrypted(false),
     _network(network),
@@ -48,8 +48,8 @@ IrcUser::IrcUser(const QString &hostmask, Network *network) : SyncableObject(net
     _codecForDecoding(0)
 {
     updateObjectName();
-    _lastAwayMessage.setTimeSpec(Qt::UTC);
-    _lastAwayMessage.setMSecsSinceEpoch(0);
+    _lastAwayMessageTime.setTimeSpec(Qt::UTC);
+    _lastAwayMessageTime.setMSecsSinceEpoch(0);
 }
 
 
@@ -217,11 +217,28 @@ void IrcUser::setIrcOperator(const QString &ircOperator)
 }
 
 
-void IrcUser::setLastAwayMessage(const QDateTime &lastAwayMessage)
+// This function is only ever called by SYNC calls from legacy cores.
+// Therefore, no SYNC call is needed here.
+void IrcUser::setLastAwayMessage(const int &lastAwayMessage)
 {
-    if (lastAwayMessage > _lastAwayMessage) {
-        _lastAwayMessage = lastAwayMessage;
-        SYNC(ARG(lastAwayMessage))
+    QDateTime lastAwayMessageTime = QDateTime();
+    lastAwayMessageTime.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= 0x050800
+    lastAwayMessageTime.fromSecsSinceEpoch(lastAwayMessage);
+#else
+    // toSecsSinceEpoch() was added in Qt 5.8.  Manually downconvert to seconds for now.
+    // See https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch
+    lastAwayMessageTime.fromMSecsSinceEpoch(lastAwayMessage * 1000);
+#endif
+    setLastAwayMessageTime(lastAwayMessageTime);
+}
+
+
+void IrcUser::setLastAwayMessageTime(const QDateTime &lastAwayMessageTime)
+{
+    if (lastAwayMessageTime > _lastAwayMessageTime) {
+        _lastAwayMessageTime = lastAwayMessageTime;
+        SYNC(ARG(lastAwayMessageTime))
     }
 }
 

--- a/src/common/ircuser.h
+++ b/src/common/ircuser.h
@@ -50,7 +50,8 @@ class IrcUser : public SyncableObject
     Q_PROPERTY(QDateTime loginTime READ loginTime WRITE setLoginTime)
     Q_PROPERTY(QString server READ server WRITE setServer)
     Q_PROPERTY(QString ircOperator READ ircOperator WRITE setIrcOperator)
-    Q_PROPERTY(QDateTime lastAwayMessage READ lastAwayMessage WRITE setLastAwayMessage)
+    Q_PROPERTY(int lastAwayMessage WRITE setLastAwayMessage)
+    Q_PROPERTY(QDateTime lastAwayMessageTime READ lastAwayMessageTime WRITE setLastAwayMessageTime)
     Q_PROPERTY(QString whoisServiceReply READ whoisServiceReply WRITE setWhoisServiceReply)
     Q_PROPERTY(QString suserHost READ suserHost WRITE setSuserHost)
     Q_PROPERTY(bool encrypted READ encrypted WRITE setEncrypted)
@@ -79,7 +80,7 @@ public :
     inline QDateTime loginTime() const { return _loginTime; }
     inline QString server() const { return _server; }
     inline QString ircOperator() const { return _ircOperator; }
-    inline QDateTime lastAwayMessage() const { return _lastAwayMessage; }
+    inline QDateTime lastAwayMessageTime() const { return _lastAwayMessageTime; }
     inline QString whoisServiceReply() const { return _whoisServiceReply; }
     inline QString suserHost() const { return _suserHost; }
     inline bool encrypted() const { return _encrypted; }
@@ -123,7 +124,8 @@ public slots:
     void setLoginTime(const QDateTime &loginTime);
     void setServer(const QString &server);
     void setIrcOperator(const QString &ircOperator);
-    void setLastAwayMessage(const QDateTime &lastAwayMessage);
+    void setLastAwayMessage(const int &lastAwayMessage);
+    void setLastAwayMessageTime(const QDateTime &lastAwayMessageTime);
     void setWhoisServiceReply(const QString &whoisServiceReply);
     void setSuserHost(const QString &suserHost);
     void setEncrypted(bool encrypted);
@@ -156,7 +158,7 @@ signals:
 //   void loginTimeSet(QDateTime loginTime);
 //   void serverSet(QString server);
 //   void ircOperatorSet(QString ircOperator);
-//   void lastAwayMessageSet(QDateTime lastAwayMessage);
+//   void lastAwayMessageTimeSet(QDateTime lastAwayMessageTime);
 //   void whoisServiceReplySet(QString whoisServiceReply);
 //   void suserHostSet(QString suserHost);
     void encryptedSet(bool encrypted);
@@ -203,7 +205,7 @@ private:
     QDateTime _idleTimeSet;
     QDateTime _loginTime;
     QString _ircOperator;
-    QDateTime _lastAwayMessage;
+    QDateTime _lastAwayMessageTime;
     QString _whoisServiceReply;
     QString _suserHost;
     bool _encrypted;

--- a/src/common/network.cpp
+++ b/src/common/network.cpp
@@ -892,16 +892,17 @@ QVariantMap Network::initIrcUsersAndChannels() const
         QHash<QString, IrcUser *>::const_iterator end = _ircUsers.end();
         while (it != end) {
             QVariantMap map = it.value()->toVariantMap();
-            // If the peer doesn't support LongTime, replace the lastAwayMessage field
-            // with the 32-bit numerical seconds value used in older versions
+            // If the peer doesn't support LongTime, replace the lastAwayMessageTime field
+            // with the 32-bit numerical seconds value (lastAwayMessage) used in older versions
             if (!proxy()->targetPeer()->hasFeature(Quassel::Feature::LongTime)) {
 #if QT_VERSION >= 0x050800
-                int lastAwayMessage = it.value()->lastAwayMessage().toSecsSinceEpoch();
+                int lastAwayMessage = it.value()->lastAwayMessageTime().toSecsSinceEpoch();
 #else
                 // toSecsSinceEpoch() was added in Qt 5.8.  Manually downconvert to seconds for now.
                 // See https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch
-                int lastAwayMessage = it.value()->lastAwayMessage().toMSecsSinceEpoch() / 1000;
+                int lastAwayMessage = it.value()->lastAwayMessageTime().toMSecsSinceEpoch() / 1000;
 #endif
+                map.remove("lastAwayMessageTime");
                 map["lastAwayMessage"] = lastAwayMessage;
             }
 
@@ -975,16 +976,16 @@ void Network::initSetIrcUsersAndChannels(const QVariantMap &usersAndChannels)
         // If the peer doesn't support LongTime, upconvert the lastAwayMessage field
         // from the 32-bit numerical seconds value used in older versions to QDateTime
         if (!proxy()->sourcePeer()->hasFeature(Quassel::Feature::LongTime)) {
-            QDateTime lastAwayMessage = QDateTime();
-            lastAwayMessage.setTimeSpec(Qt::UTC);
+            QDateTime lastAwayMessageTime = QDateTime();
+            lastAwayMessageTime.setTimeSpec(Qt::UTC);
 #if QT_VERSION >= 0x050800
-            lastAwayMessage.fromSecsSinceEpoch(map["lastAwayMessage"].toInt());
+            lastAwayMessageTime.fromSecsSinceEpoch(map.take("lastAwayMessage").toInt());
 #else
             // toSecsSinceEpoch() was added in Qt 5.8.  Manually downconvert to seconds for now.
             // See https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch
-            lastAwayMessage.fromMSecsSinceEpoch(map["lastAwayMessage"].toInt() * 1000);
+            lastAwayMessageTime.fromMSecsSinceEpoch(map.take("lastAwayMessage").toInt() * 1000);
 #endif
-            map["lastAwayMessage"] = lastAwayMessage;
+            map["lastAwayMessageTime"] = lastAwayMessageTime;
         }
 
         newIrcUser(map["nick"].toString(), map); // newIrcUser() properly handles the hostmask being just the nick

--- a/src/core/coresessioneventprocessor.cpp
+++ b/src/core/coresessioneventprocessor.cpp
@@ -846,7 +846,7 @@ void CoreSessionEventProcessor::processIrcEvent301(IrcEvent *e)
     if (ircuser) {
         ircuser->setAway(true);
         ircuser->setAwayMessage(e->params().at(1));
-        //ircuser->setLastAwayMessage(now);
+        //ircuser->setLastAwayMessageTime(now);
     }
 }
 

--- a/src/core/eventstringifier.cpp
+++ b/src/core/eventstringifier.cpp
@@ -453,9 +453,9 @@ void EventStringifier::processIrcEvent301(IrcEvent *e)
             now.setTimeSpec(Qt::UTC);
             // Don't print "user is away" messages more often than this
             const int silenceTime = 60;
-            if (ircuser->lastAwayMessage().addSecs(silenceTime) >= now)
+            if (ircuser->lastAwayMessageTime().addSecs(silenceTime) >= now)
                 send = false;
-            ircuser->setLastAwayMessage(now);
+            ircuser->setLastAwayMessageTime(now);
         }
     }
     if (send)


### PR DESCRIPTION
This will make it easier for clients to implement both at the same
time.  Also, add a backwards-compatibility function to allow old
cores to set the lastAwayMessageTime.  There is still no forwards-
compatibility (support for old clients on new cores) since no
existing clients do anything with lastAwayMessage.